### PR TITLE
Hardcoded Latest Upcoming Calls Info to Dynamic Real-Time Info

### DIFF
--- a/app/(root)/(home)/page.tsx
+++ b/app/(root)/(home)/page.tsx
@@ -1,26 +1,76 @@
-import MeetingTypeList from '@/components/MeetingTypeList';
+//@ts-nocheck
+'use client';
+
+import React from 'react';
+import { useGetCalls } from '@/hooks/useGetCalls';
+import Loader from '@/components/Loader';
+import MeetingTypesList from '@/components/MeetingTypesList';
 
 const Home = () => {
-  const now = new Date();
 
-  const time = now.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
-  const date = (new Intl.DateTimeFormat('en-US', { dateStyle: 'full' })).format(now);
+  const { upcomingCalls, isLoading } = useGetCalls();
+  if (isLoading) return <Loader />;
+
+  const currentDateTime = new Date();
+  // Format the time as 10:25 AM/PM
+  const timeFormatted = currentDateTime.toLocaleString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+  });
+
+  const dateFormatted = new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'full',
+  }).format(currentDateTime);
+
+  // Filter and sort the upcoming calls to find the latest one
+  const sortedCalls = upcomingCalls?.sort((a, b) => {
+    const dateA = new Date(a.state.startsAt$.source._value);
+    const dateB = new Date(b.state.startsAt$.source._value);
+    return dateA - dateB;
+  });
+
+  const latestCall =
+    sortedCalls?.length > 0 ? sortedCalls[0].state.startsAt : null;
 
   return (
-    <section className="flex size-full flex-col gap-5 text-white">
-      <div className="h-[303px] w-full rounded-[20px] bg-hero bg-cover">
-        <div className="flex h-full flex-col justify-between max-md:px-5 max-md:py-8 lg:p-11">
-          <h2 className="glassmorphism max-w-[273px] rounded py-2 text-center text-base font-normal">
-            Upcoming Meeting at: 12:30 PM
-          </h2>
+    <section className="size-full flex flex-col gap-10 text-white">
+      <div className="h-[300px] w-full rounded-[20px] bg-hero bg-cover">
+        <div className="flex flex-col h-full justify-between max-md:px-5 max-md:py-8 lg:p-11">
+          {latestCall ? (
+            <h2 className="glassmorphism max-w-[270px] rounded-md py-2 text-center text-base font-normal">
+              <p>Upcoming meeting at</p>
+              <span className="text-red-500 font-bold">
+                {new Date(latestCall)
+                  .toLocaleString('en-US', {
+                    month: 'short',
+                    day: '2-digit',
+                    year: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    hour12: true,
+                  })
+                  .replace(',', '')}
+              </span>
+            </h2>
+          ) : (
+            <h2 className="glassmorphism max-w-[270px] rounded-md py-2 text-center text-base font-normal">
+              No Upcoming meetings!
+            </h2>
+          )}
+
           <div className="flex flex-col gap-2">
-            <h1 className="text-4xl font-extrabold lg:text-7xl">{time}</h1>
-            <p className="text-lg font-medium text-sky-1 lg:text-2xl">{date}</p>
+            <h1 className="text-4xl font-extrabold lg:text-7xl">
+              {timeFormatted}
+            </h1>
+            <p className="font-medium text-sky-1 text-lg lg:text-2xl">
+              {dateFormatted}
+            </p>
           </div>
         </div>
       </div>
 
-      <MeetingTypeList />
+      <MeetingTypesList />
     </section>
   );
 };


### PR DESCRIPTION
![image](https://github.com/adrianhajdin/zoom-clone/assets/94049470/41dd9595-7410-4da5-82f4-bb9e4ca0f1ae)

This PR refactors the Home component to replace the hardcoded logic for displaying the latest upcoming calls/meetings with a dynamic approach that fetches real-time data. This ensures the displayed information is always up-to-date.

#### Changes Made:
Refactored the Home component to use the useGetCalls hook to fetch real-time data for upcoming calls.
Sorted the fetched calls to determine the latest upcoming call.
Added logic to handle cases where there are no upcoming calls/meetings.
Improved the date and time formatting to ensure consistent display.

##### Before:
The upcoming calls/meetings were hardcoded, resulting in static and outdated information being displayed.

##### After:
The upcoming calls/meetings are fetched dynamically, ensuring the latest real-time data is always displayed.